### PR TITLE
Add reactive hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,16 +15,16 @@ Example,
 
 ```python
 
-from rubylib import bundler, gem, ruby_dist_dir
+from rubylib import bundle, gem, ruby_dist_dir
 
 print(ruby_dist_dir())
 # /var/lib/juju/agents/unit-ruby-0/charm/dist
 
 @when('ruby.available')
 def install_deps():
-    bundler('install')
+    bundle('install')
     gem('install dotenv')
-    bundler('exec rails s')
+    bundle('exec rails s')
 
 ```
 

--- a/reactive/ruby.py
+++ b/reactive/ruby.py
@@ -1,7 +1,8 @@
 from charms.reactive import (
-    hook,
     set_state,
-    remove_state
+    remove_state,
+    when,
+    when_not
 )
 
 from charmhelpers.core import hookenv
@@ -13,12 +14,10 @@ import rubylib
 config = hookenv.config()
 
 
-@hook('install')
+@when_not('ruby.installed')
 def install_ruby():
-    """ Installs defined ruby
 
-    Emits:
-    ruby.available: Emitted once the runtime has been installed
+    """ Installs defined ruby
     """
     remove_state('ruby.available')
 
@@ -39,4 +38,31 @@ def install_ruby():
     rubylib.compile_ruby()
 
     hookenv.status_set('active', 'Ruby is ready!')
+    set_state('ruby.installed')
+
+
+@when('ruby.installed')
+def ruby_avail():
+
+    """ Sets the ruby available state
+
+    Emits:
+    ruby.available: Emitted once the runtime has been installed
+    """
     set_state('ruby.available')
+
+
+@when_not('ruby.installed')
+def ruby_unavail():
+
+    """ Sets remove ruby.available
+    """
+    remove_state('ruby.available')
+
+
+@when('config.set.ruby-version')
+def version_changed():
+
+    """ React to ruby version changed
+    """
+    remove_state('ruby.installed')

--- a/reactive/ruby.py
+++ b/reactive/ruby.py
@@ -19,8 +19,6 @@ def install_ruby():
 
     """ Installs defined ruby
     """
-    remove_state('ruby.available')
-
     # Cleanup any packaged ruby
     hookenv.log('Removing any packaged Ruby', 'debug')
     apt_purge(['ruby'])
@@ -37,7 +35,6 @@ def install_ruby():
     # Install
     rubylib.compile_ruby()
 
-    hookenv.status_set('active', 'Ruby is ready!')
     set_state('ruby.installed')
 
 
@@ -49,6 +46,7 @@ def ruby_avail():
     Emits:
     ruby.available: Emitted once the runtime has been installed
     """
+    hookenv.status_set('active', 'Ruby is ready!')
     set_state('ruby.available')
 
 
@@ -58,11 +56,3 @@ def ruby_unavail():
     """ Sets remove ruby.available
     """
     remove_state('ruby.available')
-
-
-@when('config.set.ruby-version')
-def version_changed():
-
-    """ React to ruby version changed
-    """
-    remove_state('ruby.installed')


### PR DESCRIPTION
- Added @when_not('ruby.installed') in place of @hook('install')
- Added ruby_avail handler, config.changed handler for ruby version

This also fixes an issue where ruby gets re-downloaded and re-installed every time the install hook runs.
